### PR TITLE
Patches

### DIFF
--- a/.lune/generate/documentation.json
+++ b/.lune/generate/documentation.json
@@ -2359,17 +2359,17 @@
 					},
 					"GetDistance": {
 						"description": "Gets the approximate distance to the part. Accuracy falls off exponentially.",
-						"parameters": ["part: Part"],
+						"parameters": ["part: PilotObject"],
 						"returns": ["number"]
 					},
 					"GetPartsInRange": {
 						"description": "Does a (power hungry) query for all parts in the configured (or specified) range up to 1024 studs. Can optionally filter for a class name, but many use cases will prefer to store part objects in a set.",
 						"parameters": ["range: number?", "className: string?"],
-						"returns": ["{Part}"]
+						"returns": ["{PilotObject}"]
 					},
 					"Locate": {
 						"description": "Uses GPS to locate a part (uses :GetDistance() internally). The scanners you provide should be on different axes and stuff. You need at least 3 to correctly identify a position.",
-						"parameters": ["part: Part", "scanners: {Scanner}"],
+						"parameters": ["part: PilotObject", "scanners: {Scanner}"],
 						"returns": ["Vector3"]
 					}
 				},

--- a/.lune/generate/generators/Darklua.luau
+++ b/.lune/generate/generators/Darklua.luau
@@ -14,7 +14,7 @@ function Darklua.save(options, generatedData)
 		},
 	}
 
-	for _, module in fs.readDir("./.lune/generate/modules") do
+	for _, module in fs.readDir("./.lune/generate/object-data/pilot-modules") do
 		table.insert(darkluaConfig.bundle.excludes, Utility.stripFileExtension(module))
 	end
 

--- a/.lune/pilot-generate.luau
+++ b/.lune/pilot-generate.luau
@@ -19,9 +19,6 @@ end
 if argumentsSpecified then
 	stdio.write("Arguments besides '-o' and `--types-dir` specified, not providing Q/A.\n")
 else
-	options.o = process.args[1] or "./workspace"
-	options["types-dir"] = process.args[2] or "types"
-
 	stdio.write(stdio.color("red"))
 	stdio.write("Note: ")
 	stdio.write(stdio.color("reset"))


### PR DESCRIPTION
- Fixes incorrect `Scanner` types, they used `Part` instead of `PilotObject`.
- Fixes darklua generating the wrong file excludes, it was using the wrong directory.
- Fix specifying the `-o` and `--types-dir` option when no other options are specified.